### PR TITLE
Debugged with AXIS 7011 video server.

### DIFF
--- a/RTSP Client Test/Form1.cs
+++ b/RTSP Client Test/Form1.cs
@@ -222,11 +222,14 @@ namespace RTSP_Client_Test
 			}
 			else
 			{
-				if (!m_rtspClient.LivePlay)
-				{
-					label2.Text = "Remaining: " +
-						(DateTime.UtcNow - m_rtspClient.StartedPlaying.Value).Subtract(m_rtspClient.EndTime.Value).ToString();
-				}
+        if (m_rtspClient != null)
+        {
+          if (!m_rtspClient.LivePlay)
+          {
+            label2.Text = "Remaining: " +
+              (DateTime.UtcNow - m_rtspClient.StartedPlaying.Value).Subtract(m_rtspClient.EndTime.Value).ToString();
+          }
+        }
 				/*
 				RTSPMessagesTextBox.AppendText("RTSPClient_RtcpPacketReceieved" + Environment.NewLine);
 				RTSPMessagesTextBox.AppendText("@" + packet.Created.ToUniversalTime().ToString() + " - " + packet.ToString() + Environment.NewLine);
@@ -248,11 +251,14 @@ namespace RTSP_Client_Test
 			}
 			else
 			{
-				if (!m_rtspClient.LivePlay)
-				{
-					label2.Text = "Remaining: " +
-						(DateTime.UtcNow - m_rtspClient.StartedPlaying.Value).Subtract(m_rtspClient.EndTime.Value).ToString();
-				}
+        if ((m_rtspClient != null))
+        {
+          if (!m_rtspClient.LivePlay)
+          {
+            label2.Text = "Remaining: " +
+              (DateTime.UtcNow - m_rtspClient.StartedPlaying.Value).Subtract(m_rtspClient.EndTime.Value).ToString();
+          }
+        }
 				RTSPMessagesTextBox.AppendText("RTSPClient_RtpPacketReceieved" + Environment.NewLine);
 				RTSPMessagesTextBox.AppendText("@" + packet.Created.ToUniversalTime().ToString() + " - " + packet.ToString() + Environment.NewLine);
 

--- a/Rtsp/RtspClient.cs
+++ b/Rtsp/RtspClient.cs
@@ -376,7 +376,7 @@ namespace Media.Rtsp
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
-                return Common.IDisposedExtensions.IsNullOrDisposed(Client) ? null : (TimeSpan?)Client.TransportContexts.Max(tc => tc.MediaEndTime);
+                return Common.IDisposedExtensions.IsNullOrDisposed(Client) ? null : ((Client.TransportContexts.Count==0) ? null : (TimeSpan?)Client.TransportContexts.Max(tc => tc.MediaEndTime));
             }
         }   //Remaining?   /// <summary>
         /// If playing, indicates if the RtspClient is playing from a live source which means there is no absolute start or end time and seeking may not be supported.

--- a/Sdp/MediaDescription.cs
+++ b/Sdp/MediaDescription.cs
@@ -435,15 +435,34 @@ namespace Media.Sdp
 
             //If there is a control line in the SDP it contains the URI used to setup and control the media
             if (controlLine != null)
-            {  
-                //Todo, make typed line for controlLine
-                string controlPart = controlLine.Parts.Last(); //controlLine.Parts.Where(p => p.StartsWith(AttributeFields.Control)).FirstOrDefault();
+            {
 
+        //Todo, make typed line for controlLine
+        // GC: Rewrote this somewhat because it was destroying valid absolute URL provided by AXIS media server in the MediaDescription Control field.
+        //     This make break media servers which use a relative path. TODO: Test with other servers.
+        string controlPart = "";
+        if (controlLine.Parts.Count() > 2)
+        {
+          foreach (string part in controlLine.Parts)
+          {
+            if (part == "control") { }
+            else if (part == "rtsp")
+              controlPart += part + ":";
+            else
+              controlPart += part;
+          }
+        } else
+        {
+          controlPart = controlLine.Parts.Last();
+        }
+        
                 //If there is a controlPart in the controlLine
                 if (false == string.IsNullOrWhiteSpace(controlPart))
                 {
                     //Prepare the part
-                    controlPart = controlPart.Split(Media.Sdp.SessionDescription.ColonSplit, 2, StringSplitOptions.RemoveEmptyEntries).Last();
+                    // GC: Commented this out because it was destroying valid absolute URL provided by AXIS media server in the MediaDescription Control field.
+                    //     This make break media servers which use a relative path. TODO: Test with other servers.
+                    //controlPart = controlPart.Split(Media.Sdp.SessionDescription.ColonSplit, 2, StringSplitOptions.RemoveEmptyEntries).Last();
 
                     //Create a uri
                     Uri controlUri = new Uri(controlPart, UriKind.RelativeOrAbsolute);


### PR DESCRIPTION
Fixed handling of absolute URL provided in control field of MediaDescription in SDP. Issue was seen when running with an AXIS 7011.
Fixed null object exception in EndTime getter of RtspClient.
Fixed some null object exceptions in Form1 of Client Test.